### PR TITLE
環境変数 HTTPS_PROXY のサポート

### DIFF
--- a/lib/gisty.rb
+++ b/lib/gisty.rb
@@ -164,7 +164,9 @@ class Gisty
     url = URI.parse('https://api.github.com/gists')
     req = Net::HTTP::Post.new url.path + '?access_token=' + @access_token
     req.body = params.to_json
-    https = Net::HTTP.new(url.host, url.port)
+    proxy_uri = URI.parse(ENV['https_proxy'])
+    https = Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port).new(url.host, url.port)
+
     https.use_ssl = true
     https.verify_mode = @ssl_verify
     https.verify_depth = 5


### PR DESCRIPTION
Net::HTTPが標準ではHTTPS_PROXYを読んでproxyに投げるという動作をしないので、proxy環境下では、gisty post が出来ません。
Net::HTTPオブジェクトを作成する際にHTTPS_PROXYを読み込んでNet::HTTP::Proxyに投げるようにしました。
