### PR TITLE
Fix no meta link

### DIFF
--- a/lib/gisty.rb
+++ b/lib/gisty.rb
@@ -72,11 +72,12 @@ class Gisty
       open_uri_opt[:ssl_verify_mode] = @ssl_verify
     end
     OpenURI.open_uri(url, open_uri_opt) do |f|
-      { :content => JSON.parse(f.read), :link => Gisty.parse_link(f.meta['link']) }
+      { :content => JSON.parse(f.read), :link => Gisty.parse_link(f.meta['link']) || {} }
     end
   end
 
   def self.parse_link link
+    return nil if link.nil?
     link.split(', ').inject({}) do |r, i|
       url, rel = i.split '; '
       r[rel.gsub(/^rel=/, '').gsub('"', '').to_sym] = url.gsub(/[<>]/, '').strip


### PR DESCRIPTION
lib/gisty.rb の 75行目で f.meta['link'] がnil の場合に後述のように例外を吐きました。

``` ruby
     OpenURI.open_uri(url, open_uri_opt) do |f|
       { :content => JSON.parse(f.read), :link => Gisty.parse_link(f.meta['link']) }
     end
```

https://api.github.com/gists?access_token=ACCESS_KEY

``` json
[
  {
    "files": {
      "hoge.pl": {
        "type": "application/perl",
        "language": "Perl",
        "size": 1028,
        "filename": "hoge.pl",
        "raw_url": "https://gist.github.com/raw/ACCESS_KEY/SOME_KEY/hoge.pl"
      }
    },
    "git_pull_url": "git://gist.github.com/ACCESS_KEY.git",
    "git_push_url": "git@gist.github.com:ACCESS_KEY.git",
    "comments": 0,
    "updated_at": "2012-04-26T06:45:24Z",
    "public": false,
    "user": {
      "login": "someone",
      "avatar_url": "https://secure.gravatar.com/avatar/GRAVATAR_ID?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png",
      "gravatar_id": "GRAVATAR_ID",
      "id": 74403,
      "url": "https://api.github.com/users/someone"
    },
    "html_url": "https://gist.github.com/ACCESS_KEY",
    "created_at": "2012-04-26T06:45:24Z",
    "description": null,
    "id": "ACCESS_KEY",
    "url": "https://api.github.com/gists/ACCESS_KEY"
  }
]
```

$ gisty sync                                                                                                                                                                    

```
/path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/lib/gisty.rb:80:in `parse_link': undefined method `split' for nil:NilClass (NoMethodError)
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/lib/gisty.rb:75:in `block in mygists'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/1.9.1/open-uri.rb:150:in `open_uri'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/lib/gisty.rb:74:in `mygists'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/lib/gisty.rb:49:in `block in all_mygists'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/lib/gisty.rb:48:in `times'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/lib/gisty.rb:48:in `all_mygists'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/lib/gisty.rb:125:in `block in sync'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/1.9.1/fileutils.rb:121:in `chdir'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/1.9.1/fileutils.rb:121:in `cd'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/lib/gisty.rb:124:in `sync'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/lib/commands/sync.rb:2:in `block in <top (required)>'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/bin/gisty:14:in `block in cmd'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/bin/gisty:51:in `call'
        from /path/to/rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/gisty-0.2.0/bin/gisty:51:in `<top (required)>'
        from /path/to/rbenv/versions/1.9.2-p320/bin/gisty:23:in `load'
        from /path/to/rbenv/versions/1.9.2-p320/bin/gisty:23:in `<main>'
```
