### PR TITLE
Support github enterprise API URL and access_token support.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,6 +17,7 @@ set environment variable GISTY_DIR.
     export GISTY_DIR="$HOME/dev/gists"
 
 get OAuth access token here. https://swdyh-gisty.heroku.com/
+alternatively: https://github.com/settings/applications -> "Personal access tokens"
 set environment variable GISTY_ACCESS_TOKEN
 
     export GISTY_ACCESS_TOKEN=your_access_key
@@ -34,6 +35,20 @@ if "certificate verify failed" is occurred, set environment variable GISTY_SSL_C
 if you do not want to verify, set GISTY_SSL_VERIFY.
 
     export GISTY_SSL_VERIFY="NONE"
+
+
+=== GitHub Enterprise
+
+https://enterprise.github.com/help/articles/using-the-api
+
+To set the default API access URL:
+
+    export GIST_API_URL=http(s)://github.enterprise.hostname/api/v3/gists
+
+To specify the base URI reference for the clone path (e.g. git@<path>:id.git)
+
+    export GISTY_BASE_URI=github.enterprise.hostname
+
 
 == Synopsis
 

--- a/bin/gisty
+++ b/bin/gisty
@@ -29,7 +29,8 @@ end
 if ENV['GISTY_DIR']
   begin
     @g = Gisty.new ENV['GISTY_DIR'], nil, nil, :ssl_ca => ENV['GISTY_SSL_CA'],
-      :ssl_verify => ENV['GISTY_SSL_VERIFY'], :access_token => ENV['GISTY_ACCESS_TOKEN']
+      :ssl_verify => ENV['GISTY_SSL_VERIFY'], :access_token => ENV['GISTY_ACCESS_TOKEN'],
+      :api_url => ENV['GIST_API_URL'], :base_uri => ENV['GISTY_BASE_URI']
   rescue Gisty::UnsetAuthInfoException => e
     puts 'Error: OAuth access token is missing.'
     puts 'Please get here. https://swdyh-gisty.heroku.com/'

--- a/lib/gisty.rb
+++ b/lib/gisty.rb
@@ -8,7 +8,7 @@ require 'json'
 
 class Gisty
   VERSION   = '0.2.6'
-  GIST_URL  = 'https://gist.github.com/'
+  GIST_URI  = 'gist.github.com'
   GIST_API_URL = 'https://api.github.com/gists'
   GISTY_URL = 'https://github.com/swdyh/gisty'
   USER_AGENT = "gisty/#{VERSION} #{GISTY_URL}"
@@ -42,6 +42,7 @@ class Gisty
                     OpenSSL::SSL::VERIFY_PEER
                   end
     @api_url = opt[:api_url] || GIST_API_URL
+    @base_uri = opt[:base_uri] || GIST_URI
   end
 
   def all_mygists &block
@@ -99,7 +100,7 @@ class Gisty
 
   def clone id
     FileUtils.cd @dir do
-      c = "git clone git@gist.github.com:#{id}.git"
+      c = "git clone git@#{@base_uri}:#{id}.git"
       Kernel.system c
     end
   end
@@ -133,7 +134,7 @@ class Gisty
     FileUtils.cd @dir do
       r = all_mygists do |gist|
         unless File.exists? gist['id']
-          c = "git clone git@gist.github.com:#{gist['id']}.git"
+          c = "git clone git@#{@base_uri}:#{gist['id']}.git"
           Kernel.system c
         end
         local -= [gist['id']]


### PR DESCRIPTION
It would be nice to include the [GitHub Enterprise](https://enterprise.github.com/) users with the ability to sync their gists as well (the API should be identical to the public one). This should be an easy enough configuration option (just supporting the enterprise URL). However, the OAuth token support may be a little trickier...
